### PR TITLE
tools: Chain promises in newRepo.

### DIFF
--- a/tools/newRepo
+++ b/tools/newRepo
@@ -19,56 +19,59 @@
 //  VP   V8P Y88888P  `8b8' `8d8'  88   YD Y88888P 88       `Y88P'
 
 const inquirer = require("inquirer");
-const client = require("../src/client.js"); 
+const client = require("../src/client.js");
 
 console.log("d8b   db d88888b db   d8b   db d8888b. d88888b d8888b.  .d88b.  \r\n888o  88 88\'     88   I8I   88 88  `8D 88\'     88  `8D .8P  Y8. \r\n88V8o 88 88ooooo 88   I8I   88 88oobY\' 88ooooo 88oodD\' 88    88 \r\n88 V8o88 88~~~~~ Y8   I8I   88 88`8b   88~~~~~ 88~~~   88    88 \r\n88  V888 88.     `8b d8\'8b d8\' 88 `88. 88.     88      `8b  d8\' \r\nVP   V8P Y88888P  `8b8\' `8d8\'  88   YD Y88888P 88       `Y88P\'                                  ");
 console.log("Hello, welcome to newRepo!");
 console.log("~ Create a new test repository in the zulipbot-testing organization ~\n");
+
+let username;
 
 inquirer.prompt({
   type: "input",
   name: "username",
   message: "What's your GitHub username?"
 }).then((answer) => {
-  const username = answer.username;
-  client.repos.get({
-    owner: "zulipbot-testing",
-    repo: username
-  }).then(() => {
-    console.log(`Nice try, you already have a test repository at https://github.com/zulipbot-testing/${username}. No extras :P`);
-  }, () => {
-    client.users.getForUser({
-      username: username
-    }).then(() => {
-      client.repos.createForOrg({
-        org: "zulipbot-testing",
-        name: username,
-        auto_init: true
-      })
-      .catch(console.error)
-      .then(() => {
-        console.log(`Repository successfully created at https://github.com/zulipbot-testing/${username}!`);
-        client.repos.addCollaborator({
-          owner: "zulipbot-testing",
-          repo: username,
-          username: username,
-          permission: "admin"
-        }).then(() => {
-          console.log("You now have admin access to your test repository, use it wisely!");
-          client.orgs.addOrgMembership({
-            org: "zulipbot-testing",
-            username: username,
-            role: "member"
-          })
-          .catch(console.error)
-          .then(() => {
-            console.log("Also, please accept your invitation to the zulipbot-testing organization at https://github.com/zulipbot-testing.");
-            console.log("Have fun testing!");
-          });
-        });
-      });
-    }, () => {
-      console.log("There isn't a GitHub account registered under that username! D: Try again.");
-    });
+  username = answer.username;
+  return client.users.getForUser({
+    username: username
   });
+}).catch((ex) => {
+  console.log("There isn't a GitHub account registered under that username! D: Try again.");
+  process.exit(1);
+}).then(() => {
+  return client.repos.createForOrg({
+    org: "zulipbot-testing",
+    name: username,
+    auto_init: true
+  });
+}).catch((ex) => {
+  const errorMsg = JSON.parse(ex.message);
+  if (ex.code === 422 &&
+    errorMsg.errors[0].message === "name already exists on this account") {
+    console.log("Nice try, you already have a test repository at",
+      `https://github.com/zulipbot-testing/${username}. No extras :P`);
+    process.exit(1);
+  }
+  throw ex;
+}).then(() => {
+  console.log(`Repository successfully created at https://github.com/zulipbot-testing/${username}!`);
+  return client.repos.addCollaborator({
+    owner: "zulipbot-testing",
+    repo: username,
+    username: username,
+    permission: "admin"
+  });
+}).then(() => {
+  console.log("You now have admin access to your test repository, use it wisely!");
+  return client.orgs.addOrgMembership({
+    org: "zulipbot-testing",
+    username: username,
+    role: "member"
+  });
+}).then(() => {
+  console.log("Also, please accept your invitation to the zulipbot-testing organization at https://github.com/zulipbot-testing.");
+  console.log("Have fun testing!");
+}).catch((ex) => {
+  console.error(ex);
 });


### PR DESCRIPTION
`tools/newRepo` has been refactored to keep a linear promise chain.

Also, the check to see if a repo already exists for that user is now directly managed by the potential error that GitHub's API may return when trying to create a duplicate repo.