### PR TITLE
lint: Add the code inside tools/ to the checks.

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -10,7 +10,7 @@ var plumber = require("gulp-plumber");
 var coveralls = require("gulp-coveralls");
 
 gulp.task("static", () => {
-  return gulp.src("**/*.js")
+  return gulp.src(["**/*.js", "tools/*", "!tools/setup"])
   .pipe(excludeGitignore())
   .pipe(eslint())
   .pipe(eslint.format())

--- a/tools/checkInactivity
+++ b/tools/checkInactivity
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
- //
+//
 //                          88  88               88                                                                      88
 //                          88  ""               88                         ,d           ,d                              88
 //                          88                   88                         88           88                              88
@@ -22,7 +22,7 @@ const inquirer = require("inquirer");
 const client = require("../src/client.js");
 const checkInactivity = require("../src/issues/checkInactivity.js");
 
-console.log("       _               _    ___                  _   _       _ _         \r\n   ___| |__   ___  ___| | _|_ _|_ __   __ _  ___| |_(___   _(_| |_ _   _ \r\n  \/ __| \'_ \\ \/ _ \\\/ __| |\/ \/| || \'_ \\ \/ _` |\/ __| __| \\ \\ \/ | | __| | | |\r\n | (__| | | |  __| (__|   < | || | | | (_| | (__| |_| |\\ V \/| | |_| |_| |\r\n  \\___|_| |_|\\___|\\___|_|\\_|___|_| |_|\\__,_|\\___|\\__|_| \\_\/ |_|\\__|\\__, |\r\n                                                                   |___\/ ");
+console.log("       _               _    ___                  _   _       _ _         \r\n   ___| |__   ___  ___| | _|_ _|_ __   __ _  ___| |_(___   _(_| |_ _   _ \r\n  / __| '_ \\ / _ \\/ __| |/ /| || '_ \\ / _` |/ __| __| \\ \\ / | | __| | | |\r\n | (__| | | |  __| (__|   < | || | | | (_| | (__| |_| |\\ V /| | |_| |_| |\r\n  \\___|_| |_|\\___|\\___|_|\\_|___|_| |_|\\__,_|\\___|\\__|_| \\_/ |_|\\__|\\__, |\r\n                                                                   |___/ ");
 console.log("Hello, welcome to checkInactivity!");
 console.log("~ Check your zulipbot-testing repository for inactive issues and pull requests ~\n");
 inquirer.prompt({

--- a/tools/configLint
+++ b/tools/configLint
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
- //
+//
 //                          88  88               88                                                                      88
 //                          88  ""               88                         ,d           ,d                              88
 //                          88                   88                         88           88                              88
@@ -20,10 +20,10 @@
 
 "use strict";
 
-const inquirer = require("inquirer")
+const inquirer = require("inquirer");
 const Mocha = require("mocha");
 
-console.log("                   __ _       _      _       _   \r\n                  \/ _(_)     | |    (_)     | |  \r\n   ___ ___  _ __ | |_ _  __ _| |     _ _ __ | |_ \r\n  \/ __\/ _ \\| \'_ \\|  _| |\/ _` | |    | | \'_ \\| __|\r\n | (_| (_) | | | | | | | (_| | |____| | | | | |_ \r\n  \\___\\___\/|_| |_|_| |_|\\__, |______|_|_| |_|\\__|\r\n                         __\/ |                   \r\n                        |___\/                    \n");
+console.log("                   __ _       _      _       _   \r\n                  / _(_)     | |    (_)     | |  \r\n   ___ ___  _ __ | |_ _  __ _| |     _ _ __ | |_ \r\n  / __/ _ \\| '_ \\|  _| |/ _` | |    | | '_ \\| __|\r\n | (_| (_) | | | | | | | (_| | |____| | | | | |_ \r\n  \\___\\___/|_| |_|_| |_|\\__, |______|_|_| |_|\\__|\r\n                         __/ |                   \r\n                        |___/                    \n");
 console.log("Hello, welcome to configLint!");
 console.log("~ Check your configuration file (./src/config.js) for errors! ~\n");
 
@@ -33,5 +33,5 @@ inquirer.prompt({
   message: "Are you sure you want to test ./src/config.js?"
 }).then((answer) => {
   if (!answer.confirm) return;
-  const mocha = new Mocha().addFile('./test/configLint.js').run();
+  new Mocha().addFile("./test/configLint.js").run();
 });

--- a/tools/fetchInactive
+++ b/tools/fetchInactive
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
- //
+//
 //                          88  88               88                                                                      88
 //                          88  ""               88                         ,d           ,d                              88
 //                          88                   88                         88           88                              88
@@ -18,8 +18,8 @@
 //  88      88.        88    Y8b  d8 88   88   .88.   88  V888 88   88 Y8b  d8    88      .88.    `8bd8'  88.
 //  YP      Y88888P    YP     `Y88P' YP   YP Y888888P VP   V8P YP   YP  `Y88P'    YP    Y888888P    YP    Y88888P
 
-const client = require("../src/client.js"); 
-const dateFormat = require('dateformat');
+const client = require("../src/client.js");
+const dateFormat = require("dateformat");
 let references = new Map();
 const repos = ["zulip", "zulip-mobile", "zulip-electron", "zulipbot"];
 
@@ -59,8 +59,8 @@ function scrapeInactivePullRequests(pullRequests, repoName, repoOwner) {
       repo: repoName,
       number: number
     }).then((response) => {
-      const inactiveLabel = response.data.find(label => {
-        return label.name === client.cfg.inactiveLabel
+      const inactiveLabel = response.data.find((label) => {
+        return label.name === client.cfg.inactiveLabel;
       });
       if (inactiveLabel) return;
       const reviewedLabel = response.data.find((label) => {
@@ -83,7 +83,7 @@ function scrapeInactivePullRequests(pullRequests, repoName, repoOwner) {
   });
   let issues = [];
   getIssues(issues, references, repoOwner, repoName, 1);
-};
+}
 
 function getIssues(issues, references, repoOwner, repoName, pageCount) {
   client.issues.getAll({
@@ -105,8 +105,8 @@ function getIssues(issues, references, repoOwner, repoName, pageCount) {
 
 function scrapeInactiveIssues(references, issues, owner, name) {
   issues.forEach((issue) => {
-    const inactiveLabel = issue.labels.find(label => {
-      return label.name === client.cfg.inactiveLabel
+    const inactiveLabel = issue.labels.find((label) => {
+      return label.name === client.cfg.inactiveLabel;
     });
     if (inactiveLabel) return;
     let time = Date.parse(issue.updated_at);
@@ -118,6 +118,6 @@ function scrapeInactiveIssues(references, issues, owner, name) {
     let assignees = [];
     issue.assignees.forEach(assignee => assignees.push(assignee.login));
     const assigneeString = assignees.join(", @");
-    console.log(`Claimed issue #${issueNumber} in ${repoOwner}/${repoName} is inactive.\nAssignee(s): @${assigneeString}. Last updated: ${dateFormat(time, "UTC:dddd, mmmm dS, yyyy, h:MM TT")}.\n`)
+    console.log(`Claimed issue #${issueNumber} in ${repoOwner}/${repoName} is inactive.\nAssignee(s): @${assigneeString}. Last updated: ${dateFormat(time, "UTC:dddd, mmmm dS, yyyy, h:MM TT")}.\n`);
   });
-};
+}

--- a/tools/fetchPriority
+++ b/tools/fetchPriority
@@ -20,7 +20,7 @@
 
 const client = require("../src/client.js");
 
-if (!client.cfg.priorityLabels) return console.log("No priority labels were specified in config.js!");
+if (!client.cfg.priorityLabels) console.log("No priority labels were specified in config.js!");
 
 client.cfg.priorityLabels.forEach((label) => {
   client.issues.getAll({

--- a/tools/mockPayload
+++ b/tools/mockPayload
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
- //
+//
 //                          88  88               88                                                                      88
 //                          88  ""               88                         ,d           ,d                              88
 //                          88                   88                         88           88                              88
@@ -29,7 +29,7 @@ const issueReferenced = require("../src/pullRequests/issueReferenced.js");
 const checkPullRequestComment = require("../src/issues/checkPullRequestComment.js");
 const travisBuildStatus = require("../src/pullRequests/travisBuildStatus.js");
 
-console.log("                       _    ____             _                 _ \r\n  _ __ ___   ___   ___| | _|  _ \\ __ _ _   _| | ___   __ _  __| |\r\n | \"_ ` _ \\ \/ _ \\ \/ __| |\/ | |_) \/ _` | | | | |\/ _ \\ \/ _` |\/ _` |\r\n | | | | | | (_) | (__|   <|  __| (_| | |_| | | (_) | (_| | (_| |\r\n |_| |_| |_|\\___\/ \\___|_|\\_|_|   \\__,_|\\__, |_|\\___\/ \\__,_|\\__,_|\r\n                                       |___\/                     ");
+console.log("                       _    ____             _                 _ \r\n  _ __ ___   ___   ___| | _|  _ \\ __ _ _   _| | ___   __ _  __| |\r\n | \"_ ` _ \\ / _ \\ / __| |/ | |_) / _` | | | | |/ _ \\ / _` |/ _` |\r\n | | | | | | (_) | (__|   <|  __| (_| | |_| | | (_) | (_| | (_| |\r\n |_| |_| |_|\\___/ \\___|_|\\_|_|   \\__,_|\\__, |_|\\___/ \\__,_|\\__,_|\r\n                                       |___/                     ");
 console.log("Hello, welcome to mockPayload!");
 console.log("~ Send test payloads to your repository in zulipbot-testing ~\n");
 inquirer.prompt({
@@ -104,7 +104,7 @@ inquirer.prompt({
                 "errored"
               ],
               when: (answers) => {
-                return answers.payloadType === "Pull request Travis build status updated (Travis webhook)"
+                return answers.payloadType === "Pull request Travis build status updated (Travis webhook)";
               }
             },
             {
@@ -112,7 +112,7 @@ inquirer.prompt({
               name: "buildURL",
               message: "Enter the URL of the Travis build logs for the pull request:",
               validate: (value) => {
-                var valid = /https?:\/\/(www\.)?[-a-zA-Z0-9@:%._\+~#=]{2,256}\.[a-z]{2,6}\b([-a-zA-Z0-9@:%_\+.~#?&//=]*)/.test(value);
+                var valid = /https?:\/\/(www\.)?[-a-zA-Z0-9@:%._+~#=]{2,256}\.[a-z]{2,6}\b([-a-zA-Z0-9@:%_+.~#?&//=]*)/.test(value);
                 return valid || "Please enter a valid URL!";
               },
               when: (answers) => {
@@ -123,6 +123,7 @@ inquirer.prompt({
               const travis = response.travis;
               const buildURL = response.buildURL;
               if (body && body.match(/#([0-9]+)/) && client.cfg.areaLabels) {
+                // eslint-disable-next-line no-undef
                 issueReferenced(client, body, pullRequestNumber, username, "zulipbot-testing");
                 console.log(`Payload sent! Check https://github.com/zulipbot-testing/${username}/pull/${issueNumber} for any responses.`);
               } else if (travis && buildURL && client.cfg.travisLabel) {
@@ -222,6 +223,7 @@ inquirer.prompt({
                   const splitBody = body.split(`@${client.cfg.username}`).filter((splitString) => {
                     return splitString.includes(" join \"");
                   }).join(" ");
+                  // eslint-disable-next-line no-undef
                   joinLabelTeam(client, splitBody, commenter, "zulipbot-testing", username, issueNumber);
                 }
               });

--- a/tools/newRepo
+++ b/tools/newRepo
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
- //
+//
 //                          88  88               88                                                                      88
 //                          88  ""               88                         ,d           ,d                              88
 //                          88                   88                         88           88                              88
@@ -21,7 +21,7 @@
 const inquirer = require("inquirer");
 const client = require("../src/client.js");
 
-console.log("d8b   db d88888b db   d8b   db d8888b. d88888b d8888b.  .d88b.  \r\n888o  88 88\'     88   I8I   88 88  `8D 88\'     88  `8D .8P  Y8. \r\n88V8o 88 88ooooo 88   I8I   88 88oobY\' 88ooooo 88oodD\' 88    88 \r\n88 V8o88 88~~~~~ Y8   I8I   88 88`8b   88~~~~~ 88~~~   88    88 \r\n88  V888 88.     `8b d8\'8b d8\' 88 `88. 88.     88      `8b  d8\' \r\nVP   V8P Y88888P  `8b8\' `8d8\'  88   YD Y88888P 88       `Y88P\'                                  ");
+console.log("d8b   db d88888b db   d8b   db d8888b. d88888b d8888b.  .d88b.  \r\n888o  88 88'     88   I8I   88 88  `8D 88'     88  `8D .8P  Y8. \r\n88V8o 88 88ooooo 88   I8I   88 88oobY' 88ooooo 88oodD' 88    88 \r\n88 V8o88 88~~~~~ Y8   I8I   88 88`8b   88~~~~~ 88~~~   88    88 \r\n88  V888 88.     `8b d8'8b d8' 88 `88. 88.     88      `8b  d8' \r\nVP   V8P Y88888P  `8b8' `8d8'  88   YD Y88888P 88       `Y88P'                                  ");
 console.log("Hello, welcome to newRepo!");
 console.log("~ Create a new test repository in the zulipbot-testing organization ~\n");
 
@@ -36,7 +36,7 @@ inquirer.prompt({
   return client.users.getForUser({
     username: username
   });
-}).catch((ex) => {
+}).catch(() => {
   console.log("There isn't a GitHub account registered under that username! D: Try again.");
   process.exit(1);
 }).then(() => {

--- a/tools/setup
+++ b/tools/setup
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
- //
+//
 //                          88  88               88                                                                      88
 //                          88  ""               88                         ,d           ,d                              88
 //                          88                   88                         88           88                              88
@@ -37,18 +37,20 @@ inquirer.prompt({
   if (!answer.confirm) return;
   console.log("Creating `src/config.js` file...");
   return fs.symlink(
-    path.resolve('src/zulip_project_config.js'),
-    path.resolve('src/config.js')
+    path.resolve("src/zulip_project_config.js"),
+    path.resolve("src/config.js")
   );
 }).catch((err) => {
-  if (err.code !== 'EEXIST') { throw err; }
+  if (err.code !== "EEXIST") {
+    throw err;
+  }
   console.log("`src/config.js` already exists. Skipping.");
 }).then(() => {
   console.log("Creating `src/secrets.json` file...");
   const _0x9bc6 = ["\x32\x70\x67\x4b\x52\x66\x44\x6a\x7a\x78\x46\x34\x7a\x32\x71\x5a\x50\x6a\x69\x56\x45\x71\x35\x51\x4b\x36\x41\x53\x57\x39\x30\x73",
-  "\x68\x74\x74\x70\x73\x3a\x2f\x2f\x63\x68\x61\x74\x2e\x7a\x75\x6c\x69\x70\x2e\x6f\x72\x67",
-  "\x37\x6c\x78\x47\x79\x67\x71\x6a\x72\x59\x72\x4e\x7a\x4a\x31\x76\x6d\x78\x51\x4e\x55\x42\x4e\x46",
-  "\x7a\x75\x6c\x69\x70\x62\x6f\x74\x2d\x62\x6f\x74\x40\x63\x68\x61\x74\x2e\x7a\x75\x6c\x69\x70\x2e\x6f\x72\x67"];
+    "\x68\x74\x74\x70\x73\x3a\x2f\x2f\x63\x68\x61\x74\x2e\x7a\x75\x6c\x69\x70\x2e\x6f\x72\x67",
+    "\x37\x6c\x78\x47\x79\x67\x71\x6a\x72\x59\x72\x4e\x7a\x4a\x31\x76\x6d\x78\x51\x4e\x55\x42\x4e\x46",
+    "\x7a\x75\x6c\x69\x70\x62\x6f\x74\x2d\x62\x6f\x74\x40\x63\x68\x61\x74\x2e\x7a\x75\x6c\x69\x70\x2e\x6f\x72\x67"];
   (function(_0x4c9d7b, _0x3e34e9) {
     const _0x512513 = (_0x1de104) => {
       while (--_0x1de104) _0x4c9d7b["\x70\x75\x73\x68"](_0x4c9d7b["\x73\x68\x69\x66\x74"]());
@@ -69,13 +71,13 @@ inquirer.prompt({
       "\x72\x65\x61\x6c\x6d": _0x69bc("0x3")
     }
   };
-  const serialized_secrets = JSON.stringify(placeholder_secrets, null, '    ');
+  const serialized_secrets = JSON.stringify(placeholder_secrets, null, "    ");
   return fs.writeFile("src/secrets.json", serialized_secrets);
 }).catch((err) => {
   throw err;
 }).then(() => {
   // Let's look for zulipbot's repo in the parent directory tree.
-  return Git.Repository.open(path.normalize(__dirname + '/..'));
+  return Git.Repository.open(path.resolve(__dirname, "../"));
 }).then((r) => {
   console.log("Setting up GitHub `upstream` remote...");
   console.log("> git remote add upstream https://github.com/zulip/zulipbot.git");
@@ -83,19 +85,21 @@ inquirer.prompt({
   return Git.Remote.create(repo, "upstream",
     "https://github.com/zulip/zulipbot.git");
 }).catch((err) => {
-  if (err.errno !== -4) { throw err; }
+  if (err.errno !== -4) {
+    throw err;
+  }
   console.log("Remote 'upstream' already exists. Skipping.");
   return repo.getRemote("upstream");
 }).then((remote) => {
-  console.log('Done!');
+  console.log("Done!");
   console.log("Fetching from `upstream`...");
   console.log("> git fetch upstream");
   return remote.fetch();
-}).then((number) => {
-  console.log('Done!');
+}).then(() => {
+  console.log("Done!");
   console.log("Environment setup complete.\n");
   console.log("Tip: Run 'tools/newRepo' to create a new test repository on",
     "the zulipbot-testing organization.");
 }).catch((err) => {
-  return console.log('An error occured!\n\n', err);
+  return console.log("An error occured!\n\n", err);
 });


### PR DESCRIPTION
The scripts inside `tools/` weren't being checked by the linter because they don't have the `.js` extension.

They have been added to the files passed to ESLint by Gulp, and all the violations have been fixed, with the exception of two undefined elements in `tools/mockPayload` (which needs updating) and the obfuscated data in `tools/setup`.