### PR TITLE
Remove the necessity to sign CLA for contributors.

### DIFF
--- a/config/templates/contributorAddition.md
+++ b/config/templates/contributorAddition.md
@@ -2,7 +2,6 @@ Welcome to Zulip, @{commenter}! We just sent you an invite to collaborate on thi
 
 Here's some tips to get you off to a good start:
 * Join me on the [Zulip developers' server](https://chat.zulip.org), to get help, chat about this issue, and meet the other developers.
-* Sign the [Dropbox Contributor License Agreement](https://opensource.dropbox.com/cla/), so that Zulip can use your code.
 * [Unwatch this repository](https://help.github.com/articles/unwatching-repositories/), so that you don't get 100 emails a day.
 
 As you work on this issue, you'll also want to refer to the [Zulip code contribution guide](https://zulip.readthedocs.io/en/latest/contributing/index.html), as well as the rest of the developer documentation on that site.


### PR DESCRIPTION
See the conclusion at https://chat.zulip.org/#narrow/stream/105-zulipbot/topic/New.20contributor.20definition.