### PR TITLE
dependencies: Add lodash dependency to package.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1998,8 +1998,7 @@
     "lodash": {
       "version": "4.17.20",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
-      "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
-      "dev": true
+      "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA=="
     },
     "lodash.flattendeep": {
       "version": "4.4.0",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   "dependencies": {
     "@octokit/rest": "^16.43.2",
     "express": "~4.16.3",
+    "lodash": "^4.17.20",
     "node-fetch": "^2.1.2"
   },
   "devDependencies": {


### PR DESCRIPTION
While deploying to heroku, it was throwing the following error
`Error: Cannot find module 'lodash'`.

Ran `npm i --save lodash`.

It works fine by just removing `"dev": true` from package-lock.json too (without adding anything in package.json).