### PR TITLE
Fix @octokit/rest deprecations

### DIFF
--- a/src/commands/abandon.js
+++ b/src/commands/abandon.js
@@ -7,12 +7,12 @@ exports.run = function(payload, commenter) {
   if (!assignees.includes(commenter)) {
     const error = "**ERROR:** You have not claimed this issue to work on yet.";
     return this.issues.createComment({
-      owner: repoOwner, repo: repoName, number: number, body: error
+      owner: repoOwner, repo: repoName, issue_number: number, body: error
     });
   }
 
   return this.issues.removeAssignees({
-    owner: repoOwner, repo: repoName, number: number, assignees: [commenter]
+    owner: repoOwner, repo: repoName, issue_number: number, assignees: [commenter]
   });
 };
 

--- a/src/commands/add.js
+++ b/src/commands/add.js
@@ -38,7 +38,7 @@ exports.run = async function(payload, commenter, args) {
     });
 
     this.issues.createComment({
-      owner: repoOwner, repo: repoName, number: number, body: error
+      owner: repoOwner, repo: repoName, issue_number: number, body: error
     });
   }
 
@@ -53,13 +53,13 @@ exports.run = async function(payload, commenter, args) {
     });
 
     this.issues.createComment({
-      owner: repoOwner, repo: repoName, number: number, body: error
+      owner: repoOwner, repo: repoName, issue_number: number, body: error
     });
   }
 
   if (addLabels.length) {
     response = await this.issues.addLabels({
-      owner: repoOwner, repo: repoName, number: number, labels: addLabels
+      owner: repoOwner, repo: repoName, issue_number: number, labels: addLabels
     });
   }
 

--- a/src/commands/claim.js
+++ b/src/commands/claim.js
@@ -7,14 +7,14 @@ exports.run = async function(payload, commenter, args) {
   if (payload.issue.assignees.find(assignee => assignee.login === commenter)) {
     const error = "**ERROR:** You have already claimed this issue.";
     return this.issues.createComment({
-      owner: repoOwner, repo: repoName, number: number, body: error
+      owner: repoOwner, repo: repoName, issue_number: number, body: error
     });
   }
 
   if (payload.issue.assignees.length >= limit) {
     const warn = this.templates.get("multipleClaimWarning").format({commenter});
     return this.issues.createComment({
-      owner: repoOwner, repo: repoName, number: number, body: warn
+      owner: repoOwner, repo: repoName, issue_number: number, body: warn
     });
   }
 
@@ -37,7 +37,7 @@ exports.run = async function(payload, commenter, args) {
     if (response.code !== 404) {
       const error = "**ERROR:** Unexpected response from GitHub API.";
       return this.issues.createComment({
-        owner: repoOwner, repo: repoName, number: number, body: error
+        owner: repoOwner, repo: repoName, issue_number: number, body: error
       });
     }
 
@@ -58,7 +58,7 @@ async function invite(payload, commenter, args) {
     });
 
     return this.issues.createComment({
-      owner: repoOwner, repo: repoName, number: number, body: error
+      owner: repoOwner, repo: repoName, issue_number: number, body: error
     });
   }
 
@@ -82,7 +82,7 @@ async function invite(payload, commenter, args) {
     });
 
     return this.issues.createComment({
-      owner: repoOwner, repo: repoName, number: number, body: comment
+      owner: repoOwner, repo: repoName, issue_number: number, body: comment
     });
   }
 
@@ -91,7 +91,7 @@ async function invite(payload, commenter, args) {
   if (!perm) {
     const error = "**ERROR:** `newContributors.permission` wasn't configured.";
     return this.issues.createComment({
-      owner: repoOwner, repo: repoName, number: number, body: error
+      owner: repoOwner, repo: repoName, issue_number: number, body: error
     });
   }
 
@@ -100,7 +100,7 @@ async function invite(payload, commenter, args) {
   });
 
   this.issues.createComment({
-    owner: repoOwner, repo: repoName, number: number, body: comment
+    owner: repoOwner, repo: repoName, issue_number: number, body: comment
   });
 
   this.invites.set(inviteKey, number);
@@ -128,7 +128,7 @@ async function validate(commenter, number, repoOwner, repoName) {
     });
 
     return this.issues.createComment({
-      owner: repoOwner, repo: repoName, number: number, body: comment
+      owner: repoOwner, repo: repoName, issue_number: number, body: comment
     });
   }
 
@@ -137,7 +137,7 @@ async function validate(commenter, number, repoOwner, repoName) {
 
 async function claim(commenter, number, repoOwner, repoName) {
   const response = await this.issues.addAssignees({
-    owner: repoOwner, repo: repoName, number: number, assignees: [commenter]
+    owner: repoOwner, repo: repoName, issue_number: number, assignees: [commenter]
   });
 
   if (response.data.assignees.length) return;
@@ -145,7 +145,7 @@ async function claim(commenter, number, repoOwner, repoName) {
   const error = "**ERROR:** Issue claiming failed (no assignee was added).";
 
   return this.issues.createComment({
-    owner: repoOwner, repo: repoName, number: number, body: error
+    owner: repoOwner, repo: repoName, issue_number: number, body: error
   });
 }
 

--- a/src/commands/claim.js
+++ b/src/commands/claim.js
@@ -34,7 +34,7 @@ exports.run = async function(payload, commenter, args) {
 
     return validate.apply(this, [commenter, number, repoOwner, repoName]);
   } catch (response) {
-    if (response.code !== 404) {
+    if (response.status !== 404) {
       const error = "**ERROR:** Unexpected response from GitHub API.";
       return this.issues.createComment({
         owner: repoOwner, repo: repoName, issue_number: number, body: error

--- a/src/commands/remove.js
+++ b/src/commands/remove.js
@@ -15,7 +15,7 @@ exports.run = async function(payload, commenter, args) {
   const rejected = labels.filter(label => !issueLabels.includes(label));
 
   await this.issues.replaceLabels({
-    owner: repoOwner, repo: repoName, number: number, labels: removeLabels
+    owner: repoOwner, repo: repoName, issue_number: number, labels: removeLabels
   });
 
   if (!rejected.length) return true;
@@ -31,7 +31,7 @@ exports.run = async function(payload, commenter, args) {
   });
 
   return this.issues.createComment({
-    owner: repoOwner, repo: repoName, number: number, body: error
+    owner: repoOwner, repo: repoName, issue_number: number, body: error
   });
 };
 

--- a/src/events/activity.js
+++ b/src/events/activity.js
@@ -32,7 +32,7 @@ async function scrapePulls(pulls) {
     const repoOwner = pull.base.repo.owner.login;
 
     const response = await this.issues.listLabelsOnIssue({
-      owner: repoOwner, repo: repoName, number: number
+      owner: repoOwner, repo: repoName, issue_number: number
     });
 
     const labels = response.data.map(label => label.name);
@@ -83,12 +83,12 @@ async function checkInactivePull(pull) {
   });
 
   const comments = await template.getComments({
-    owner: repoOwner, repo: repoName, number: number
+    owner: repoOwner, repo: repoName, issue_number: number
   });
 
   if (!comments.length) {
     this.issues.createComment({
-      owner: repoOwner, repo: repoName, number: number, body: comment
+      owner: repoOwner, repo: repoName, issue_number: number, body: comment
     });
   }
 }
@@ -122,7 +122,7 @@ async function scrapeInactiveIssues(references, issues) {
     if (!issue.assignees.length) {
       const comment = "**ERROR:** This active issue has no assignee.";
       return this.issues.createComment({
-        owner: repoOwner, repo: repoName, number: number, body: comment
+        owner: repoOwner, repo: repoName, issue_number: number, body: comment
       });
     }
 
@@ -134,12 +134,12 @@ async function scrapeInactiveIssues(references, issues) {
     });
 
     const comments = await template.getComments({
-      owner: repoOwner, repo: repoName, number: number
+      owner: repoOwner, repo: repoName, issue_number: number
     });
 
     if (comments.length) {
       this.issues.removeAssignees({
-        owner: repoOwner, repo: repoName, number: number, assignees: logins
+        owner: repoOwner, repo: repoName, issue_number: number, assignees: logins
       });
 
       const warning = this.templates.get("abandonWarning").format({
@@ -153,7 +153,7 @@ async function scrapeInactiveIssues(references, issues) {
       });
     } else if (time + ims <= Date.now()) {
       this.issues.createComment({
-        owner: repoOwner, repo: repoName, number: number, body: comment
+        owner: repoOwner, repo: repoName, issue_number: number, body: comment
       });
     }
   }

--- a/src/events/member.js
+++ b/src/events/member.js
@@ -12,7 +12,7 @@ exports.run = async function(payload) {
   const [repoOwner, repoName] = repoFullName.split("/");
 
   const response = await this.issues.addAssignees({
-    owner: repoOwner, repo: repoName, number: invite, assignees: [member]
+    owner: repoOwner, repo: repoName, issue_number: invite, assignees: [member]
   });
 
   this.invites.delete(`${member}@${repoFullName}`);
@@ -21,7 +21,7 @@ exports.run = async function(payload) {
 
   const error = "**ERROR:** Issue claiming failed (no assignee was added).";
   return this.issues.createComment({
-    owner: repoOwner, repo: repoName, number: invite, body: error
+    owner: repoOwner, repo: repoName, issue_number: invite, body: error
   });
 };
 

--- a/src/events/pull.js
+++ b/src/events/pull.js
@@ -16,7 +16,7 @@ exports.run = async function(payload) {
   } else if (["labeled", "unlabeled"].includes(action)) {
     const l = payload.label;
     const issue = await this.issues.get({
-      owner: repo.owner.login, repo: repo.name, number: pull.number
+      owner: repo.owner.login, repo: repo.name, issue_number: pull.number
     });
     this.responses.get("areaLabel").run(issue.data, repo, l);
   }

--- a/src/events/responses/areaLabel.js
+++ b/src/events/responses/areaLabel.js
@@ -29,7 +29,7 @@ exports.run = async function(issue, repo, label) {
   });
 
   const comments = await template.getComments({
-    owner: repoOwner, repo: repoName, number: number
+    owner: repoOwner, repo: repoName, issue_number: number
   });
 
   const tag = `${repoOwner}/${repoName}#${number}`;
@@ -47,7 +47,7 @@ exports.run = async function(issue, repo, label) {
     }
   } else if (!referenced.includes(tag) && issueAreaLabels.length) {
     this.issues.createComment({
-      owner: repoOwner, repo: repoName, number: number, body: comment
+      owner: repoOwner, repo: repoName, issue_number: number, body: comment
     });
 
     // Ignore labels added in bulk

--- a/src/events/responses/issueState.js
+++ b/src/events/responses/issueState.js
@@ -25,7 +25,7 @@ async function clearClosed(issue, repo) {
   });
 
   await this.issues.removeAssignees({
-    owner: repoOwner, repo: repoName, number: issue.number, body: assignees
+    owner: repoOwner, repo: repoName, issue_number: issue.number, body: assignees
   });
 
   recentlyClosed.delete(issue.id);
@@ -48,11 +48,11 @@ exports.progress = function(payload) {
 
   if (action === "assigned" && !labeled) {
     this.issues.addLabels({
-      owner: repoOwner, repo: repoName, number: number, labels: [label]
+      owner: repoOwner, repo: repoName, issue_number: number, labels: [label]
     });
   } else if (action === "unassigned" && !assigned && labeled) {
     this.issues.removeLabel({
-      owner: repoOwner, repo: repoName, number: number, name: label
+      owner: repoOwner, repo: repoName, issue_number: number, name: label
     });
   }
 };

--- a/src/events/responses/mergeConflict.js
+++ b/src/events/responses/mergeConflict.js
@@ -18,7 +18,7 @@ async function check(number, repo) {
   const {branch, label, comment} = this.cfg.pulls.status.mergeConflicts;
 
   const pull = await this.pulls.get({
-    owner: repoOwner, repo: repoName, number: number
+    owner: repoOwner, repo: repoName, pull_number: number
   });
 
   const mergeable = pull.data.mergeable;
@@ -30,13 +30,13 @@ async function check(number, repo) {
   });
 
   const warnings = await template.getComments({
-    owner: repoOwner, repo: repoName, number: number
+    owner: repoOwner, repo: repoName, issue_number: number
   });
 
   // Use a strict false check; unknown merge conflict statuses return null
   if (mergeable === false) {
     const commits = await this.util.getAllPages("pulls.listCommits", {
-      owner: repoOwner, repo: repoName, number: number
+      owner: repoOwner, repo: repoName, pull_number: number
     });
     const lastCommitTime = commits.slice(-1).pop().commit.committer.date;
 
@@ -45,7 +45,7 @@ async function check(number, repo) {
     });
 
     const labels = await this.issues.listLabelsOnIssue({
-      owner: repoOwner, repo: repoName, number: number
+      owner: repoOwner, repo: repoName, issue_number: number
     });
     const inactive = labels.data.find(l => {
       return l.name === this.cfg.activity.inactive;
@@ -55,13 +55,13 @@ async function check(number, repo) {
 
     if (!warnComment && comment) {
       this.issues.createComment({
-        owner: repoOwner, repo: repoName, number: number, body: warning
+        owner: repoOwner, repo: repoName, issue_number: number, body: warning
       });
     }
 
     if (label) {
       await this.issues.addLabels({
-        owner: repoOwner, repo: repoName, number: number, labels: [label]
+        owner: repoOwner, repo: repoName, issue_number: number, labels: [label]
       });
     }
   }

--- a/src/events/responses/pullState.js
+++ b/src/events/responses/pullState.js
@@ -8,7 +8,7 @@ exports.label = async function(payload) {
   const action = payload.action;
 
   const response = await this.issues.listLabelsOnIssue({
-    owner: repoOwner, repo: repoName, number: number
+    owner: repoOwner, repo: repoName, issue_number: number
   });
 
   let labels = response.data.map(label => label.name);
@@ -29,7 +29,7 @@ exports.label = async function(payload) {
 
   if (!_.isEqual(oldLabels.sort(), labels.sort())) {
     await this.issues.replaceLabels({
-      owner: repoOwner, repo: repoName, number: number, labels: labels
+      owner: repoOwner, repo: repoName, issue_number: number, labels: labels
     });
   }
 
@@ -63,7 +63,7 @@ async function size(sizeLabels, labels, number, repo) {
   const pullLabels = labels.filter(label => !sizeLabels.has(label));
 
   const files = await this.util.getAllPages("pulls.listFiles", {
-    owner: repoOwner, repo: repoName, number: number
+    owner: repoOwner, repo: repoName, pull_number: number
   });
 
   const changes = files.filter(file => {
@@ -92,7 +92,7 @@ exports.assign = function(payload) {
   const number = payload.pull_request.number;
 
   this.issues.addAssignees({
-    owner: repoOwner, repo: repoName, number: number, assignees: [reviewer]
+    owner: repoOwner, repo: repoName, issue_number: number, assignees: [reviewer]
   });
 };
 
@@ -104,7 +104,7 @@ exports.update = async function(pull, repo) {
   const warnings = new Map([
     ["mergeConflictWarning", async() => {
       const pullInfo = await this.pulls.get({
-        owner: repoOwner, repo: repoName, number: number
+        owner: repoOwner, repo: repoName, pull_number: number
       });
       return new Promise(resolve => resolve(pullInfo.data.mergeable));
     }],
@@ -126,7 +126,7 @@ exports.update = async function(pull, repo) {
     if (label) {
       try {
         await this.issues.removeLabel({
-          owner: repoOwner, repo: repoName, number: number, name: label
+          owner: repoOwner, repo: repoName, issue_number: number, name: label
         });
       } catch (e) {
         // although we could attempt to fetch labels of the pull request,
@@ -135,7 +135,7 @@ exports.update = async function(pull, repo) {
     }
 
     const comments = await template.getComments({
-      number: number, owner: repoOwner, repo: repoName
+      issue_number: number, owner: repoOwner, repo: repoName
     });
 
     if (!comments.length) continue;

--- a/src/events/responses/reference.js
+++ b/src/events/responses/reference.js
@@ -14,7 +14,7 @@ exports.run = async function(pull, repo, opened) {
 
   const template = this.templates.get("fixCommitWarning");
   const comments = await template.getComments({
-    number: number, owner: repoOwner, repo: repoName
+    issue_number: number, owner: repoOwner, repo: repoName
   });
 
   if (!comments.length && missingRefs.length) {
@@ -24,7 +24,7 @@ exports.run = async function(pull, repo, opened) {
       issuePronoun: missingRefs.length ? "them" : "it"
     });
     return this.issues.createComment({
-      owner: repoOwner, repo: repoName, number: number, body: comment
+      owner: repoOwner, repo: repoName, issue_number: number, body: comment
     });
   }
 
@@ -41,7 +41,7 @@ async function labelReference(refIssue, number, repo) {
   const labelCfg = this.cfg.pulls.references.labels;
 
   const response = await this.issues.listLabelsOnIssue({
-    owner: repoOwner, repo: repoName, number: refIssue
+    owner: repoOwner, repo: repoName, issue_number: refIssue
   });
 
   let labels = response.data.map(label => label.name);
@@ -54,7 +54,7 @@ async function labelReference(refIssue, number, repo) {
     if (cfgCheck.filter(defined).length !== 1) {
       const error = "**ERROR:** Invalid `references.labels` configuration.";
       return this.issues.createComment({
-        owner: repoOwner, repo: repoName, number: number, body: error
+        owner: repoOwner, repo: repoName, issue_number: number, body: error
       });
     }
 
@@ -68,6 +68,6 @@ async function labelReference(refIssue, number, repo) {
   }
 
   this.issues.addLabels({
-    owner: repoOwner, repo: repoName, number: number, labels: labels
+    owner: repoOwner, repo: repoName, issue_number: number, labels: labels
   });
 }

--- a/src/events/travis.js
+++ b/src/events/travis.js
@@ -6,7 +6,7 @@ exports.run = async function(payload) {
   const number = payload.pull_request_number;
 
   const labels = await this.issues.listLabelsOnIssue({
-    owner: repoOwner, repo: repoName, number: number
+    owner: repoOwner, repo: repoName, issue_number: number
   });
 
   const labelCheck = labels.data.find(label => {
@@ -28,7 +28,7 @@ exports.run = async function(payload) {
   }
 
   return this.issues.createComment({
-    owner: repoOwner, repo: repoName, number: number, body: comment
+    owner: repoOwner, repo: repoName, issue_number: number, body: comment
   });
 };
 

--- a/src/structures/ReferenceSearch.js
+++ b/src/structures/ReferenceSearch.js
@@ -70,7 +70,7 @@ class ReferenceSearch {
     const statusCheck = matches.map(async number => {
       if (!number) return false;
       const issue = await this.client.issues.get({
-        owner: this.repoOwner, repo: this.repoName, number: number
+        owner: this.repoOwner, repo: this.repoName, issue_number: number
       });
       // valid references are open issues
       const valid = !issue.data.pull_request && issue.data.state === "open";
@@ -92,7 +92,7 @@ class ReferenceSearch {
 
   async getCommits() {
     const commits = await this.client.pulls.listCommits({
-      owner: this.repoOwner, repo: this.repoName, number: this.number
+      owner: this.repoOwner, repo: this.repoName, pull_number: this.number
     });
 
     const msgs = commits.data.map(c => c.commit.message);

--- a/test/unit/commands/claim.js
+++ b/test/unit/commands/claim.js
@@ -57,7 +57,7 @@ test("Throw error if collaborator check code isn't 404", async t => {
   const commenter = "octokitten";
 
   const request1 = simple.mock(client.repos, "checkCollaborator").rejectWith({
-    code: 500
+    status: 500
   });
 
   const error = "**ERROR:** Unexpected response from GitHub API.";
@@ -76,7 +76,7 @@ test("Rejects creation of duplicate invite", async t => {
   const commenter = "octokitten";
 
   const request1 = simple.mock(client.repos, "checkCollaborator").rejectWith({
-    code: 404
+    status: 404
   });
 
   const template = client.templates.get("inviteError");
@@ -103,7 +103,7 @@ test("Blocks claim if labels are missing", async t => {
   client.cfg.issues.commands.assign.newContributors.warn.labels = ["a", "b"];
 
   const request1 = simple.mock(client.repos, "checkCollaborator").rejectWith({
-    code: 404
+    status: 404
   });
 
   const template = client.templates.get("claimBlock");
@@ -129,7 +129,7 @@ test("Warns if labels are present without force flag", async t => {
   };
 
   const request1 = simple.mock(client.repos, "checkCollaborator").rejectWith({
-    code: 404
+    status: 404
   });
 
   const template = client.templates.get("claimWarning");
@@ -151,7 +151,7 @@ test("Invite new contributor", async t => {
   const commenter = "octokitten";
 
   const request1 = simple.mock(client.repos, "checkCollaborator").rejectWith({
-    code: 404
+    status: 404
   });
 
   const template = client.templates.get("contributorAddition");
@@ -178,7 +178,7 @@ test("Throw error if permission is not specified", async t => {
   client.cfg.issues.commands.assign.newContributors.permission = null;
 
   const request1 = simple.mock(client.repos, "checkCollaborator").rejectWith({
-    code: 404
+    status: 404
   });
 
   const error = "**ERROR:** `newContributors.permission` wasn't configured.";


### PR DESCRIPTION
The `number` parameter is deprecated in octokit/rest and `issue_number` and `pull_number` parameters are used now for all methods related to `issues` and `pulls` respectively.

Also, `response.code` is deprecated in octokit promise response and `response.status` is used now.

Here's the error stack:
```
2021-01-28T11:57:44.763718+00:00 app[web.1]: { Deprecation: [@octokit/request-error] `error.code` is deprecated, use `error.status`.
2021-01-28T11:57:44.763729+00:00 app[web.1]:     at RequestError.get (/app/node_modules/@octokit/request/node_modules/@octokit/request-error/dist-node/index.js:29:17)
2021-01-28T11:57:44.763730+00:00 app[web.1]:     at Object.exports.run (/app/src/commands/claim.js:37:18)
2021-01-28T11:57:44.763730+00:00 app[web.1]:     at process._tickCallback (internal/process/next_tick.js:68:7) name: 'Deprecation' }
2021-01-28T11:57:44.766479+00:00 app[web.1]: { Deprecation: [@octokit/rest] "number" parameter is deprecated for ".issues.createComment()". Use "issue_number" instead
2021-01-28T11:57:44.766480+00:00 app[web.1]:     at Object.keys.forEach.key (/app/node_modules/@octokit/plugin-rest-endpoint-methods/dist-node/index.js:13145:26)
2021-01-28T11:57:44.766481+00:00 app[web.1]:     at Array.forEach (<anonymous>)
2021-01-28T11:57:44.766482+00:00 app[web.1]:     at Object.patchedMethod [as createComment] (/app/node_modules/@octokit/plugin-rest-endpoint-methods/dist-node/index.js:13142:26)
2021-01-28T11:57:44.766482+00:00 app[web.1]:     at Object.invite (/app/src/commands/claim.js:84:24)
2021-01-28T11:57:44.766483+00:00 app[web.1]:     at Object.exports.run (/app/src/commands/claim.js:44:19)
2021-01-28T11:57:44.766483+00:00 app[web.1]:     at process._tickCallback (internal/process/next_tick.js:68:7) name: 'Deprecation' }
```

Fixed both the deprecations in this pull request.

**Note:** I used `issue_comment` parameter in `template.getComments()` becuase issues api is being used in this method.
https://github.com/zulip/zulipbot/blob/a68d0db8731d8d0357a28d470d96251d4fc5f037/src/structures/Template.js#L30