### PR TITLE
Fix shortening of allowed inactivity on an issue from 14 to 4 days after the first warning.

### DIFF
--- a/src/events/activity.js
+++ b/src/events/activity.js
@@ -148,7 +148,7 @@ async function scrapeInactiveIssues(references, issues) {
       });
 
       const id = comments[0].id;
-      this.issues.editComment({
+      this.issues.updateComment({
         owner: repoOwner, repo: repoName, comment_id: id, body: warning
       });
     } else if (time + ims <= Date.now()) {

--- a/src/events/responses/areaLabel.js
+++ b/src/events/responses/areaLabel.js
@@ -37,7 +37,7 @@ exports.run = async function(issue, repo, label) {
   if (comments.length) {
     const id = comments[0].id;
     if (issueAreaLabels.length) {
-      this.issues.editComment({
+      this.issues.updateComment({
         owner: repoOwner, repo: repoName, comment_id: id, body: comment
       });
     } else {


### PR DESCRIPTION
There is a bug in Zulipbot due to which once a warning message is posted on an issue, every new contributor who claims the issue gets unassigned from the issue after only 4 days of inactivity, without any warning.

On closely inspecting the cause of the bug, I found that when the Zulipbot unassigns someone from the issue, it also edits the warning message sent before from `inactiveWarning` template to `abandonWarning` template. And for the next time, it just looks for the `inactiveWarning` comment in the issue and if it finds this comment in the issue after 4 days of inactivity, it assumes that that comment was posted recently by Zulipbot after 10 days of inactivity and hence unassigns the issue assuming the user has been inactive from the last 14days.

This whole problem is occurring due to the use of a deprecated API method, `editComment`.

Thus, this PR replaces the deprecated `editComment` method with `updateComment` method.