### PR TITLE
Test on Node.js 18

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -10,7 +10,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [16.x]
+        node-version: [16.x, 18.x]
 
     steps:
       - uses: actions/checkout@v2

--- a/package.json
+++ b/package.json
@@ -49,7 +49,8 @@
   "homepage": "https://github.com/zulip/zulipbot#readme",
   "tap": {
     "test-env": [
-      "NODE_ENV=test"
+      "NODE_ENV=test",
+      "NODE_OPTIONS=--no-experimental-fetch"
     ]
   }
 }


### PR DESCRIPTION
We need to disable the new `fetch` implementation for now due to https://github.com/nock/nock/issues/2183.