### PR TITLE
claim: Update logic to check whether a commenter is a contributor.

### DIFF
--- a/src/commands/claim.js
+++ b/src/commands/claim.js
@@ -103,12 +103,18 @@ export const run = async function (payload, commenter, args) {
     return invite.call(this, payload, commenter);
   }
 
-  const contributors = await this.util.getAllPages("repos.listContributors", {
+  // A commenter is considered a contributor if they have at least one commit
+  // in the repository. So, fetching just one commit by the author is sufficient
+  // to determine whether they are a contributor or not.
+  const commenterCommitsResponse = await this.repos.listCommits({
     owner: repoOwner,
     repo: repoName,
+    author: commenter,
+    per_page: 1,
   });
 
-  if (contributors.some((c) => c.login === commenter)) {
+  if (commenterCommitsResponse.data.length > 0) {
+    // commenter is a contributor
     return claim.call(this, commenter, number, repoOwner, repoName);
   }
 

--- a/test/unit/commands/claim.js
+++ b/test/unit/commands/claim.js
@@ -206,15 +206,16 @@ test("Throw error if permission is not specified", async () => {
   scope.done();
 });
 
-test("Always assign if commenter is contributor", async () => {
+test("Always assign if commenter has at least one commit", async () => {
   const commenter = "octocat";
   client.cfg.issues.commands.assign.warn.presence = false;
 
   const scope = nock("https://api.github.com")
     .get(`/repos/zulip/zulipbot/collaborators/${commenter}`)
     .reply(204)
-    .get("/repos/zulip/zulipbot/contributors")
-    .reply(200, [{ login: "octocat" }])
+    .get(`/repos/zulip/zulipbot/commits`)
+    .query({ author: commenter, per_page: 1 })
+    .reply(200, [{ sha: "dummysha123" }])
     .post("/repos/zulip/zulipbot/issues/69/assignees", {
       assignees: ["octocat"],
     })
@@ -232,8 +233,9 @@ test("Error if no assignees were added", async () => {
   const scope = nock("https://api.github.com")
     .get(`/repos/zulip/zulipbot/collaborators/${commenter}`)
     .reply(204)
-    .get("/repos/zulip/zulipbot/contributors")
-    .reply(200, [{ login: "octocat" }])
+    .get(`/repos/zulip/zulipbot/commits`)
+    .query({ author: commenter, per_page: 1 })
+    .reply(200, [{ sha: "dummysha123" }])
     .post("/repos/zulip/zulipbot/issues/69/assignees", {
       assignees: ["octocat"],
     })
@@ -252,7 +254,8 @@ test("Assign if claim limit validation passed", async () => {
   const scope = nock("https://api.github.com")
     .get(`/repos/zulip/zulipbot/collaborators/${commenter}`)
     .reply(204)
-    .get("/repos/zulip/zulipbot/contributors")
+    .get(`/repos/zulip/zulipbot/commits`)
+    .query({ author: commenter, per_page: 1 })
     .reply(200, [])
     .get("/issues?filter=all&labels=in%20progress")
     .reply(200, [])
@@ -276,7 +279,8 @@ test("Reject claim limit validation failed", async () => {
   const scope = nock("https://api.github.com")
     .get(`/repos/zulip/zulipbot/collaborators/${commenter}`)
     .reply(204)
-    .get("/repos/zulip/zulipbot/contributors")
+    .get(`/repos/zulip/zulipbot/commits`)
+    .query({ author: commenter, per_page: 1 })
     .reply(200, [])
     .get("/issues?filter=all&labels=in%20progress")
     .reply(200, [{ assignees: [{ login: "octocat" }] }])
@@ -297,7 +301,8 @@ test("Reject claim limit validation failed (limit over 1)", async () => {
   const scope = nock("https://api.github.com")
     .get(`/repos/zulip/zulipbot/collaborators/${commenter}`)
     .reply(204)
-    .get("/repos/zulip/zulipbot/contributors")
+    .get(`/repos/zulip/zulipbot/commits`)
+    .query({ author: commenter, per_page: 1 })
     .reply(200, [])
     .get("/issues?filter=all&labels=in%20progress")
     .reply(200, [


### PR DESCRIPTION
Fixes #230.

Previous logic fetched all contributors in the repo and checked whether the commenter is a contributor or not. 
The present logic fetches the commits of the commenter directly in the repo and checks whether they are contributor by verifying that number of commits are atleast one.