### PR TITLE
templates: Update wording to be more prescriptive.

### DIFF
--- a/config/templates/claimBlock.md
+++ b/config/templates/claimBlock.md
@@ -1,5 +1,3 @@
-Hello @{commenter}!
+@{commenter} You have attempted to claim an issue {state} the {labelGrammar} {list}. To learn how to pick up issues, please work through all the "Prior to picking up your first issue" sections of the [Zulip contributor guide](https://zulip.readthedocs.io/en/latest/contributing/index.html).
 
-Thanks for your interest in Zulip! You have attempted to claim an issue {state} the {labelGrammar} {list}. You can only claim and submit pull requests for issues with the [help wanted](https://github.com/{repoOwner}/{repoName}/issues?q=is%3Aopen+is%3Aissue+no%3Aassignee+label%3A%22help+wanted%22) label.
-
-If this is your first time here, we recommend reading our [guide for new contributors](https://zulip.readthedocs.io/en/latest/overview/contributing.html) before getting started.
+Please be mindful that attempting to claim issues that aren't available wastes time for other Zulip community members.

--- a/config/templates/claimPullRequest.md
+++ b/config/templates/claimPullRequest.md
@@ -1,3 +1,1 @@
-Hello @{commenter}!
-
-You have attempted to claim a pull request, which is someone else's proposed solution for an issue. Please review our [guide for new contributors](https://zulip.readthedocs.io/en/latest/overview/contributing.html) to learn how to find an issue to work on.
+@{commenter} You have attempted to claim a pull request, which is someone else's proposed solution for an issue. To learn how to pick up issues, please work through all the "Prior to picking up your first issue" sections of the [Zulip contributor guide](https://zulip.readthedocs.io/en/latest/contributing/index.html). You will also need to learn the basics of [how to use GitHub](https://docs.github.com/en/get-started).

--- a/config/templates/claimRestriction.md
+++ b/config/templates/claimRestriction.md
@@ -1,3 +1,1 @@
-Hello @{commenter}, it looks like you've currently claimed {limit} {issue} in this repository. We encourage new contributors to focus their efforts on at most {limit} {issue} at a time, so please complete your work on your other claimed issues before trying to claim this issue again.
-
-We look forward to your valuable contributions!
+@{commenter} You can't claim this issue, as you're already working on {limit} {issue} in this repository. Please make sure that every issue assigned to you has a pull request 100% ready for the next round of review. After that, you can post a comment describing the status of your other work (including links to all open PRs), and asking for this issue to be assigned.

--- a/config/templates/fixCommitWarning.md
+++ b/config/templates/fixCommitWarning.md
@@ -1,4 +1,4 @@
-Hello @{author}, it seems like you have referenced #{issues} in your pull request description, but you have not referenced {issuePronoun} in your commit message description(s). Referencing an issue in a commit message automatically closes the corresponding issue when the commit is merged, which makes the issue tracker easier to manage.
+@{author} You've referenced #{issues} in your pull request description, but you have not referenced {issuePronoun} in your commit message description(s). Referencing an issue in a commit message automatically closes the corresponding issue when the commit is merged, which makes the issue tracker easier to manage.
 
 Please run `git commit --amend` in your command line client to amend your commit message description with `Fixes #{fixIssues}.`.
 
@@ -14,6 +14,6 @@ Date:   Sat Mar 18 13:42:40 2017 -0700
     Fixes #51.
 ```
 
-To learn how to write a great commit message, please refer to our [guide](https://zulip.readthedocs.io/en/latest/contributing/version-control.html#commit-messages).
+In addition, please make sure your commit structure and messages follow all [guidelines](https://zulip.readthedocs.io/en/latest/contributing/version-control.html#commit-messages).
 
 <!-- fixCommitWarning -->

--- a/config/templates/multipleClaimWarning.md
+++ b/config/templates/multipleClaimWarning.md
@@ -1,1 +1,1 @@
-@{commenter} This issue cannot be claimed, as someone else is already working on it. Please see our [contributor guide](https://zulip.readthedocs.io/en/latest/overview/contributing.html#your-first-codebase-contribution) for advice on finding an issue to work on. Thanks!
+@{commenter} This issue cannot be claimed, as someone else is already working on it. To learn how to pick up issues, please work through all the "Prior to picking up your first issue" sections of the [Zulip contributor guide](https://zulip.readthedocs.io/en/latest/contributing/index.html).


### PR DESCRIPTION
Also remove "Hello"s.

## Questions
1. Should we drop claimWarning and the logic around it? (I never see it in action.)
2. Why don't I ever see needsReviewWarning (which I'm not sure we need) and updateWarning?